### PR TITLE
Fix PREFIX variable for debian binary packages

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,4 +18,7 @@ export DH_OPTIONS
 
 
 %:
-	dh $@ 
+	dh $@
+
+override_dh_auto_install:
+	dh_auto_install -- PREFIX=/usr


### PR DESCRIPTION
Fix PREFIX variable for debian binary packages

Packaging was configured to use the default PREFIX (/usr/local), and
this breaks bin package creation. This change injects the correct PREFIX of
`/usr`.

This addresses the following problem: https://launchpad.net/~zerovm-ci/+archive/zerovm-latest/+build/5641455 - https://launchpadlibrarian.net/167690804/buildlog_ubuntu-precise-amd64.zvm-validator_0.9-20140227002452-git3405696-1_FAILEDTOBUILD.txt.gz
