### PR TITLE
README: update summary for clarity

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,8 @@
-validator for linux x86-64 platform extracted from the native client project
-and adopted. rdtsc instruction moved to "blacklist". unlike other blacklisted
-instructions rdtsc being replaced with nops (not halts)
+ZeroVM Validator for the linux x86-64 platform is derived from the Native
+Client (NaCl) project.
+
+The `rdtsc` instruction has been moved to the "blacklist". Unlike other
+blacklisted instructions, `rdtsc` is replaced with nops (not halts).
 
 to make validator (release version) run
   make validator


### PR DESCRIPTION
README: update summary for clarity

This change is meant to clarify the opening summary of zvm-validator.

I'm also adding this as a trivial change to test the build triggers for http://ci.oslab.cc/job/zvm-validator-latest/.
