### PR TITLE
fix deprecation of _BSD_SOURCE define

### DIFF
--- a/native_client/src/shared/gio/Makefile.am
+++ b/native_client/src/shared/gio/Makefile.am
@@ -9,6 +9,7 @@ XX_CPPFLAGS = $(AM_CPPFLAGS) \
 	   '-DNACL_OSX=0' \
 	   '-DNACL_WINDOWS=0' \
 	   '-D_BSD_SOURCE=1' \
+           '-D_DEFAULT_SOURCE=1' \
 	   '-D_POSIX_C_SOURCE=199506' \
 	   '-D_XOPEN_SOURCE=600' \
 	   '-D_GNU_SOURCE=1' \

--- a/native_client/src/shared/platform/Makefile.am
+++ b/native_client/src/shared/platform/Makefile.am
@@ -60,6 +60,7 @@ XX_CPPFLAGS = $(AM_CPPFLAGS) \
 	   '-DNACL_OSX=0' \
 	   '-DNACL_WINDOWS=0' \
 	   '-D_BSD_SOURCE=1' \
+           '-D_DEFAULT_SOURCE=1' \
 	   '-D_POSIX_C_SOURCE=199506' \
 	   '-D_XOPEN_SOURCE=600' \
 	   '-D_GNU_SOURCE=1' \

--- a/native_client/src/shared/utils/Makefile.am
+++ b/native_client/src/shared/utils/Makefile.am
@@ -9,6 +9,7 @@ XX_CPPFLAGS = $(AM_CPPFLAGS) \
 	   '-DNACL_OSX=0' \
 	   '-DNACL_WINDOWS=0' \
 	   '-D_BSD_SOURCE=1' \
+           '-D_DEFAULT_SOURCE=1' \
 	   '-D_POSIX_C_SOURCE=199506' \
 	   '-D_XOPEN_SOURCE=600' \
 	   '-D_GNU_SOURCE=1' \

--- a/native_client/src/trusted/cpu_features/Makefile.am
+++ b/native_client/src/trusted/cpu_features/Makefile.am
@@ -15,6 +15,7 @@ XX_CPPFLAGS = $(AM_CPPFLAGS) \
 	   '-DNACL_OSX=0' \
 	   '-DNACL_WINDOWS=0' \
 	   '-D_BSD_SOURCE=1' \
+           '-D_DEFAULT_SOURCE=1' \
 	   '-D_POSIX_C_SOURCE=199506' \
 	   '-D_XOPEN_SOURCE=600' \
 	   '-D_GNU_SOURCE=1' \

--- a/native_client/src/trusted/service_runtime/Makefile.am
+++ b/native_client/src/trusted/service_runtime/Makefile.am
@@ -46,6 +46,7 @@ XX_CPPFLAGS = $(AM_CPPFLAGS) \
 	   '-DNACL_OSX=0' \
 	   '-DNACL_WINDOWS=0' \
 	   '-D_BSD_SOURCE=1' \
+           '-D_DEFAULT_SOURCE=1' \
 	   '-D_POSIX_C_SOURCE=199506' \
 	   '-D_XOPEN_SOURCE=600' \
 	   '-D_GNU_SOURCE=1' \

--- a/native_client/src/trusted/validator/Makefile.am
+++ b/native_client/src/trusted/validator/Makefile.am
@@ -119,6 +119,7 @@ XX_CPPFLAGS = $(AM_CPPFLAGS) \
 	   '-DNACL_OSX=0' \
 	   '-DNACL_WINDOWS=0' \
 	   '-D_BSD_SOURCE=1' \
+           '-D_DEFAULT_SOURCE=1' \
 	   '-D_POSIX_C_SOURCE=199506' \
 	   '-D_XOPEN_SOURCE=600' \
 	   '-D_GNU_SOURCE=1' \

--- a/native_client/src/trusted/validator_x86/Makefile.am
+++ b/native_client/src/trusted/validator_x86/Makefile.am
@@ -24,6 +24,7 @@ XX_CPPFLAGS = $(AM_CPPFLAGS) \
 	   '-DNACL_OSX=0' \
 	   '-DNACL_WINDOWS=0' \
 	   '-D_BSD_SOURCE=1' \
+           '-D_DEFAULT_SOURCE=1' \
 	   '-D_POSIX_C_SOURCE=199506' \
 	   '-D_XOPEN_SOURCE=600' \
 	   '-D_GNU_SOURCE=1' \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -13,6 +13,7 @@ validator_LDADD = ../native_client/src/trusted/validator/libvalidator.la
 XX_CPPFLAGS = $(AM_CPPFLAGS) \
 	'-DNACL_LINUX=1' \
 	'-D_BSD_SOURCE=1' \
+           '-D_DEFAULT_SOURCE=1' \
 	'-D_POSIX_C_SOURCE=199506' \
 	'-D_XOPEN_SOURCE=600' \
 	'-D_GNU_SOURCE=1' \


### PR DESCRIPTION
_BSD_SOURCE is deprecated in newer gcc
added _DEFAULT_SOURCE to fix that
