### PR TITLE
fix warning in test build

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -27,6 +27,7 @@ XX_CPPFLAGS = $(AM_CPPFLAGS) \
 
 valz_CPPFLAGS = $(XX_CPPFLAGS)
 valzo_CPPFLAGS = $(XX_CPPFLAGS)
+validator_CPPFLAGS = $(XX_CPPFLAGS)
 
 valz_LDADD = ../native_client/src/trusted/validator/libvalidator.la
 valzo_LDADD = ../native_client/src/trusted/validator/libvalidator.la

--- a/test/validate.c
+++ b/test/validate.c
@@ -1,10 +1,6 @@
 #include <stdio.h>
 #include <stdint.h>
-
-typedef enum {
-  FALSE,
-  TRUE
-} Bool;
+#include "native_client/src/trusted/validator_x86/ncenuminsts.h"
 
 int main()
 {
@@ -24,7 +20,7 @@ int main()
   p = (uint8_t*)(((uintptr_t)buf + 31) & ~31);
 
   /* validate buffer */
-  status = NaClSegmentValidates(p, 32, p);
+  status = NaClSegmentValidates(p, 32, (NaClPcAddress) p);
   printf("validation %s\n", status == TRUE ? "successful" : "failed");
   printf("buf = 0x%lX, aligned = 0x%lX\n", (uintptr_t)buf, (uintptr_t)p);
 


### PR DESCRIPTION
`test/validate.c` was not including key definitions, produced warnings